### PR TITLE
keep spaces in compiled values

### DIFF
--- a/src/app/converter/converter.test.ts
+++ b/src/app/converter/converter.test.ts
@@ -60,6 +60,12 @@ describe('Converter class', () => {
       expect(foundDeclaration.compiledValue).to.equal('#1e3c59');
     });
 
+    it('should work for values with spaces', () => {
+      let foundDeclaration = Utils.getDeclarationByName(results, '$multiple-variables');
+
+      expect(foundDeclaration.compiledValue).to.equal('52px solid red');
+    });
+
   });
 
   describe('Multiple input files', () => {

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -21,7 +21,7 @@ export class Utils {
 
 
   public static unWrapValue(wrappedContent: string): string {
-    wrappedContent = wrappedContent.replace(/\s/g, '');
+    wrappedContent = wrappedContent.replace(/\n/g, '');
 
     let matches = wrappedContent.match(UNWRAPPER_PATTERN);
 


### PR DESCRIPTION
The compiled value for `$multiple-variables`, for example, should be "52px solid red" instead of "52pxsolidred".  The collapsing of spaces is creating an invalid value here.