### PR TITLE
Fix error on complex variable value containing quotes

### DIFF
--- a/src/app/converter/converter.test.ts
+++ b/src/app/converter/converter.test.ts
@@ -143,6 +143,16 @@ describe('Converter class', () => {
     });
   });
 
+  describe('function result support', () => {
+    it('should return correct compiledValue when function is used', () => {
+      let opts = { inputFiles: path.resolve('./test/scss/_functions.scss'), includePaths: [] };
+      let converter = new Converter(opts);
+      let structured = converter.getStructured();
+
+      expect(structured.variables[1].compiledValue).to.be.equal('bootstrap/');
+    })
+  });
+
   describe('map support', () => {
     it('should work even if input files is not an array', () => {
       let opts = { inputFiles: path.resolve('./test/scss/_maps.scss'), includePaths: [] };

--- a/src/app/parser/parser.ts
+++ b/src/app/parser/parser.ts
@@ -3,7 +3,9 @@ const VALUE_PATERN = '[^;]+|"(?:[^"]+|(?:\\\\"|[^"])*)"';
 const DECLARATION_PATTERN =
   `\\$'?(${VARIABLE_PATERN})'?\\s*:\\s*(${VALUE_PATERN})(?:\\s*!(global|default)\\s*;|\\s*;(?![^\\{]*\\}))`;
 
-const MAP_DECLARATIOM_REGEX =  /'?((?!\d)[\w_-][\w\d_-]*)'?\s*:\s*([^,)]+)/gi;
+const MAP_DECLARATIOM_REGEX = /'?((?!\d)[\w_-][\w\d_-]*)'?\s*:\s*([^,)]+)/gi;
+const QUOTES_PATTERN = /^(['"]).*\1$/;
+const QUOTES_REPLACE = /^(['"])|(['"])$/g;
 
 const SECTION_TAG = 'sass-export-section';
 const SECTION_PATTERN = `(@${SECTION_TAG}=)(".+")`;
@@ -128,7 +130,11 @@ export class Parser {
     }
 
     let name = matches[1].trim().replace('_', '-');
-    let value = matches[2].trim().replace(/\s*\n+\s*|\"/g, '');
+    let value = matches[2].trim().replace(/\s*\n+\s*/g, '');
+
+    if (value.match(QUOTES_PATTERN)) {
+      value = value.replace(QUOTES_REPLACE, '');
+    }
 
     return { name, value } as IDeclaration;
   }

--- a/test/scss/_functions.scss
+++ b/test/scss/_functions.scss
@@ -1,0 +1,3 @@
+
+$other-var: true;
+$test-function-export: if($other-var, "bootstrap/", "../fonts/bootstrap/");

--- a/test/scss/_variables.scss
+++ b/test/scss/_variables.scss
@@ -61,7 +61,6 @@ $font-size-large: 18px;
 $icon-font-size: $font-size-small;
 $icon-font-size-lg: $font-size-large;
 
-
 //@sass-export=false
 $brand-colors: (
   'gray-light': $brand-gray-light,


### PR DESCRIPTION
Basically issue commed from this line in bootstrap variables
$icon-font-path: if($bootstrap-sass-asset-helper, "bootstrap/", "../fonts/bootstrap/") !default;

it missed "compiledValue" , cause was replacing all quotes, should be only on string values