### PR TITLE
Add failing test for maps with double quote keys

### DIFF
--- a/src/app/parser/parser.test.ts
+++ b/src/app/parser/parser.test.ts
@@ -186,6 +186,38 @@ describe('Parser class', () => {
       expect(parsedArray[0].mapValue[1].value).be.equal('$bp-medium');
     });
 
+    it('should parse map with single quote keys', () => {
+      let content = `$breakpoints: (
+        'small': 767px,
+        'medium': $bp-medium,
+        'large': 1200px
+      );`;
+
+      let parser = new Parser(content);
+      let parsedArray = parser.parse();
+
+      expect(parsedArray[0].mapValue[0].name).be.equal('small');
+      expect(parsedArray[0].mapValue[0].value).be.equal('767px');
+
+      expect(parsedArray[0].mapValue[1].value).be.equal('$bp-medium');
+    });
+
+    it('should parse map with double quote keys', () => {
+      let content = `$breakpoints: (
+        "small": 767px,
+        "medium": $bp-medium,
+        "large": 1200px
+      );`;
+
+      let parser = new Parser(content);
+      let parsedArray = parser.parse();
+
+      expect(parsedArray[0].mapValue[0].name).be.equal('small');
+      expect(parsedArray[0].mapValue[0].value).be.equal('767px');
+
+      expect(parsedArray[0].mapValue[1].value).be.equal('$bp-medium');
+    });
+
     it('should ignore comments inline', () => {
       let content = `
           $font-size: (


### PR DESCRIPTION
Hello!

I think there has been an unintentional breaking change released under 1.0.3.

We when we updated from 1.0.2 to 1.0.3 our application breaks.

I have included test coverage for this and have attempted to fix it but my knowledge of regex is not good enough to solve this issue, sorry for this.

In the meantime you might want to consider reverting the changes in the 1.0.3 release and doing a 1.1.0 release that removes the breaking change.

https://semver.org/#what-do-i-do-if-i-accidentally-release-a-backwards-incompatible-change-as-a-minor-version

Let me know if there's anything more I can do, thanks for maintaining this library it's really helpful for us.