### PR TITLE
Allow function support in map values

### DIFF
--- a/src/app/converter/converter.test.ts
+++ b/src/app/converter/converter.test.ts
@@ -194,6 +194,27 @@ describe('Converter class', () => {
       expect(map[1].value).to.be.equal('map-get($icons, music)');
       expect(map[1].compiledValue).to.be.equal('value');
     });
+
+    it('should allow function calls with multiple arguments in values', () => {
+      let result = structured['funcs'][0];
+      expect(result).to.have.property('mapValue');
+      let map = result.mapValue;
+
+      let expected = [
+        { name: 'max', value: 'max(1px, 4px)', compiled: '4px' },
+        { name: 'min', value: 'min(1px, 4px)', compiled: '1px' },
+        { name: 'str-index', value: 'str-index("Helvetica Neue", "Neue")', compiled: '11' },
+        { name: 'adjust-color', value: 'adjust-color(#d2e1dd, $red: -10, $blue: 10)', compiled: '#c8e1e7' },
+        { name: 'rgba', value: 'rgba(255, 0, 0, .5)', compiled: 'rgba(255, 0, 0, 0.5)' },
+        { name: 'darken', value: 'darken(#b37399, 20%)', compiled: '#7c4465' }
+      ];
+
+      expected.forEach(({name, value, compiled}, ix) => {
+        expect(map[ix].name).to.be.equal(name);
+        expect(map[ix].value).to.be.equal(value);
+        expect(map[ix].compiledValue).to.be.equal(compiled);
+      });
+    });
   });
 
   describe('mixins support', () => {

--- a/src/app/parser/parser.test.ts
+++ b/src/app/parser/parser.test.ts
@@ -256,5 +256,38 @@ describe('Parser class', () => {
       expect(map[0].name).be.equal('two');
       expect(map[0].value).be.equal('map-get($source, one)');
     });
+
+    it('should allow function calls with multiple arguments in values', () => {
+      let content = `$funcs: (
+        max: max(1px, 4px), // 4px
+        min: min(1px, 4px), // 1px
+        str-index: str-index("Helvetica Neue", "Neue"), // 11
+        adjust-color: adjust-color(#d2e1dd, $red: -10, $blue: 10), // #c8e1e7
+        rgba: rgba(255, 0, 0, .5), // rgba(255, 0, 0, 0.5)
+        darken: darken(#b37399, 20%), // #7c4465
+      );`;
+
+      let parser = new Parser(content);
+      let structured = parser.parseStructured();
+      let map = structured.variables[0].mapValue;
+
+      expect(map[0].name).be.equal('max');
+      expect(map[0].value).be.equal('max(1px, 4px)');
+
+      expect(map[1].name).be.equal('min');
+      expect(map[1].value).be.equal('min(1px, 4px)');
+
+      expect(map[2].name).be.equal('str-index');
+      expect(map[2].value).be.equal('str-index("Helvetica Neue", "Neue")');
+
+      expect(map[3].name).be.equal('adjust-color');
+      expect(map[3].value).be.equal('adjust-color(#d2e1dd, $red: -10, $blue: 10)');
+
+      expect(map[4].name).be.equal('rgba');
+      expect(map[4].value).be.equal('rgba(255, 0, 0, .5)');
+
+      expect(map[5].name).be.equal('darken');
+      expect(map[5].value).be.equal('darken(#b37399, 20%)');
+    });
   });
 });

--- a/src/app/parser/parser.ts
+++ b/src/app/parser/parser.ts
@@ -3,7 +3,7 @@ const VALUE_PATERN = '[^;]+|"(?:[^"]+|(?:\\\\"|[^"])*)"';
 const DECLARATION_PATTERN =
   `\\$['"]?(${VARIABLE_PATERN})['"]?\\s*:\\s*(${VALUE_PATERN})(?:\\s*!(global|default)\\s*;|\\s*;(?![^\\{]*\\}))`;
 
-const MAP_DECLARATIOM_REGEX = /['"]?((?!\d)[\w_-][\w\d_-]*)['"]?\s*:\s*(map-get\([^\)]+\)|[^\),\/]+)/gi;
+const MAP_DECLARATIOM_REGEX = /['"]?((?!\d)[\w_-][\w\d_-]*)['"]?\s*:\s*([a-z\-]+\([^\)]+\)|[^\),\/]+)/gi;
 
 const QUOTES_PATTERN = /^(['"]).*\1$/;
 const QUOTES_REPLACE = /^(['"])|(['"])$/g;

--- a/test/scss/_maps.scss
+++ b/test/scss/_maps.scss
@@ -27,3 +27,13 @@ $map-get: (
   breakpoint: map-get($bps, 'mobile'),
   icon: map-get($icons, music)
 );
+
+// @sass-export-section="funcs"
+$funcs: (
+  max: max(1px, 4px),
+  min: min(1px, 4px),
+  str-index: str-index("Helvetica Neue", "Neue"),
+  adjust-color: adjust-color(#d2e1dd, $red: -10, $blue: 10),
+  rgba: rgba(255, 0, 0, .5),
+  darken: darken(#b37399, 20%)
+);


### PR DESCRIPTION
Fixes #47 to allow support for multi-argument functions in map property values such as `rgba`.