### PR TITLE
fix: filter out the comments of sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 dist/
 .DS_Store
 node_modules/

--- a/src/app/converter/converter.ts
+++ b/src/app/converter/converter.ts
@@ -86,7 +86,11 @@ export class Converter {
 
     let contents = inputs.map((filePath) => fs.readFileSync(String(filePath)));
 
-    return contents.join(LINE_BREAK);
+    let strContents = contents.join(LINE_BREAK);
+    strContents = strContents.replace(/\/\*[\w\W\r\n]*?\*\//g, '');
+    strContents = strContents.split(LINE_BREAK).filter(v=> v.indexOf('//') === -1).join(LINE_BREAK);
+
+    return strContents;
   }
 
 


### PR DESCRIPTION
# 过滤掉sass文件中的注释
* 使用getArray和getStructured时，发现被注释的内容也可以被解析。
* 固增加此段代码，过滤掉sass文件中的注释。