### PR TITLE
Only use inspect() when working with maps - Fixes #68

### DIFF
--- a/src/app/converter/converter.ts
+++ b/src/app/converter/converter.ts
@@ -21,12 +21,19 @@ export class Converter {
     let parsedDeclarations = new Parser(content).parse();
 
     return parsedDeclarations.map((declaration) => {
-      declaration.compiledValue = this.renderPropertyValue(content, declaration);
+      let isMap = false;
+
+      if (declaration.mapValue) {
+        isMap = true;
+      }
+
+      declaration.compiledValue = this.renderPropertyValue(content, declaration, isMap);
       declaration.name = `$${declaration.name}`;
+
 
       if (declaration.mapValue) {
         declaration.mapValue.map((mapDeclaration) => {
-          mapDeclaration.compiledValue = this.renderPropertyValue(content, mapDeclaration);
+          mapDeclaration.compiledValue = this.renderPropertyValue(content, mapDeclaration, true);
           return mapDeclaration;
         });
       }
@@ -49,14 +56,19 @@ export class Converter {
 
     groups.forEach((group) => {
       let content = this.getContent();
-
+      let isMap = false;
       let compiledGroup = structuredDeclaration[group].map((declaration) => {
-        declaration.compiledValue = this.renderPropertyValue(content, declaration);
+
+        if (declaration.mapValue) {
+          isMap = true;
+        }
+
+        declaration.compiledValue = this.renderPropertyValue(content, declaration, isMap);
         declaration.name = `$${declaration.name}`;
 
         if (declaration.mapValue) {
           declaration.mapValue.map((mapDeclaration) => {
-            mapDeclaration.compiledValue = this.renderPropertyValue(content, mapDeclaration);
+            mapDeclaration.compiledValue = this.renderPropertyValue(content, mapDeclaration, true);
             return mapDeclaration;
           });
         }
@@ -95,17 +107,17 @@ export class Converter {
     let parsedMixins = new Mixins(this.getContent()).parse();
 
     if (parsedMixins && parsedMixins.length) {
-      structuredDeclaration[mixinsGroup] =  parsedMixins;
+      structuredDeclaration[mixinsGroup] = parsedMixins;
     }
 
     return structuredDeclaration;
   }
 
 
-  private renderPropertyValue(content: string, declaration: IDeclaration): string {
+  private renderPropertyValue(content: string, declaration: IDeclaration, isMap: boolean): string {
     try {
       let rendered = sass.renderSync({
-        data: content + LINE_BREAK + Utils.wrapCss(declaration),
+        data: content + LINE_BREAK + Utils.wrapCss(declaration, isMap),
         includePaths: this.options.includePaths,
         outputStyle: 'compressed'
       });

--- a/src/app/utils/utils.test.ts
+++ b/src/app/utils/utils.test.ts
@@ -33,8 +33,8 @@ describe('Utils class', () => {
 
   it('should wrap a variable', () => {
     let declaration = { name: 'var', value: '$the-value', compiledValue: '' };
-    let expectedResult = '#sass-export-id.var{content:"#{inspect($the-value)}";}';
-    let wrapped = Utils.wrapCss(declaration);
+    let expectedResult = '#sass-export-id.var{content:"#{$the-value}";}';
+    let wrapped = Utils.wrapCss(declaration, false);
 
     expect(wrapped).to.be.equal(expectedResult);
   });

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -15,8 +15,11 @@ export class Utils {
   }
 
 
-  public static wrapCss(cssDeclaration: IDeclaration): string {
-    return `${WRAPPER_CSS_ID}.${cssDeclaration.name}{content:"#{inspect(${cssDeclaration.value})}";}`;
+  public static wrapCss(cssDeclaration: IDeclaration, useInspect: boolean): string {
+    if (useInspect) {
+      return `${WRAPPER_CSS_ID}.${cssDeclaration.name}{content:"#{inspect(${cssDeclaration.value})}";}`;
+    }
+    return `${WRAPPER_CSS_ID}.${cssDeclaration.name}{content:"#{${cssDeclaration.value}}";}`;
   }
 
   public static removeDoubleQuotes(wrappedContent: string): string {

--- a/test/scss/_variables.scss
+++ b/test/scss/_variables.scss
@@ -60,6 +60,7 @@ $font-size-small: 15px;
 $font-size-large: 18px;
 $icon-font-size: $font-size-small;
 $icon-font-size-lg: $font-size-large;
+$comma-seperated-list: Arial, Helvetica, sans-serif;
 
 //@sass-export=false
 $brand-colors: (


### PR DESCRIPTION
Hi @civanm, @civan 

This PR fixes a regression where a string variable with commas would cause an error. See #68 .

We only use inspect when we know we are working with a map. In any other case we are skipping the inspect.
I have also added a variable to test the new behavior.