### PR TITLE
Add support for maps with numeric keys

### DIFF
--- a/src/app/converter/converter.test.ts
+++ b/src/app/converter/converter.test.ts
@@ -213,6 +213,24 @@ describe('Converter class', () => {
         expect(map[ix].compiledValue).to.be.equal(compiled);
       });
     });
+
+    it('should allow maps with numeric keys', () => {
+      let result = structured['levels'][0];
+      expect(result).to.have.property('mapValue');
+      let map = result.mapValue;
+
+      let expected = [
+        { name: '100', value: '80%', compiledValue: '80%' },
+        { name: '500', value: '0', compiledValue: '0' },
+        { name: '900', value: '80%', compiledValue: '80%' },
+      ];
+
+      expected.forEach(({name, value, compiledValue}, ix) => {
+        expect(map[ix].name).to.be.equal(name);
+        expect(map[ix].value).to.be.equal(value);
+        expect(map[ix].compiledValue).to.be.equal(compiledValue);
+      });
+    });
   });
 
   describe('mixins support', () => {

--- a/src/app/parser/parser.test.ts
+++ b/src/app/parser/parser.test.ts
@@ -47,6 +47,12 @@ describe('Parser class', () => {
 
     expect(parser.parse()).that.is.an('array');
     expect(parser.parse()).to.be.empty;
+
+    rawContent = '$0: test;';
+    parser = new Parser(rawContent);
+
+    expect(parser.parse()).that.is.an('array');
+    expect(parser.parse()).to.be.empty;
   });
 
   describe('parseStructured Validations', () => {
@@ -228,6 +234,26 @@ describe('Parser class', () => {
       expect(parsedArray[0].mapValue[1].value).be.equal('$bp-medium');
     });
 
+    it('should parse map with numeric keys', () => {
+      let content = `$levels: (
+        100: 80%,
+        500: 0,
+        900: 80%
+      );`;
+
+      let parser = new Parser(content);
+      let parsedArray = parser.parse();
+
+      expect(parsedArray[0].mapValue[0].name).be.equal('100');
+      expect(parsedArray[0].mapValue[0].value).be.equal('80%');
+
+      expect(parsedArray[0].mapValue[1].name).be.equal('500');
+      expect(parsedArray[0].mapValue[1].value).be.equal('0');
+
+      expect(parsedArray[0].mapValue[2].name).be.equal('900');
+      expect(parsedArray[0].mapValue[2].value).be.equal('80%');
+    });
+
     it('should ignore comments inline', () => {
       let content = `
           $font-size: (
@@ -397,6 +423,32 @@ describe('Parser class', () => {
       expect(parsedArray[0].mapValue[2].mapValue[0].value).be.equal('1200px');
 
       expect(parsedArray[0].mapValue[2].mapValue[1].value).be.equal('$bp-xl');
+    });
+
+    it('should parse map with numeric keys', () => {
+      let content = `$content: (
+        0: 0,
+        1: 1,
+        2: (
+          0: 0,
+          1: 1,
+          2: 2
+        )
+      );`;
+
+      let parser = new Parser(content);
+      let parsedArray = parser.parse();
+
+      expect(parsedArray[0].mapValue[2].name).be.equal('2');
+
+      expect(parsedArray[0].mapValue[2].mapValue[0].name).be.equal('0');
+      expect(parsedArray[0].mapValue[2].mapValue[0].value).be.equal('0');
+
+      expect(parsedArray[0].mapValue[2].mapValue[1].name).be.equal('1');
+      expect(parsedArray[0].mapValue[2].mapValue[1].value).be.equal('1');
+
+      expect(parsedArray[0].mapValue[2].mapValue[2].name).be.equal('2');
+      expect(parsedArray[0].mapValue[2].mapValue[2].value).be.equal('2');
     });
   });
 });

--- a/src/app/utils/utils.test.ts
+++ b/src/app/utils/utils.test.ts
@@ -33,7 +33,7 @@ describe('Utils class', () => {
 
   it('should wrap a variable', () => {
     let declaration = { name: 'var', value: '$the-value', compiledValue: '' };
-    let expectedResult = '#sass-export-id.var{content:"#{$the-value}";}';
+    let expectedResult = '#sass-export-id._var{content:"#{$the-value}";}';
     let wrapped = Utils.wrapCss(declaration, false);
 
     expect(wrapped).to.be.equal(expectedResult);

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -17,9 +17,9 @@ export class Utils {
 
   public static wrapCss(cssDeclaration: IDeclaration, useInspect: boolean): string {
     if (useInspect) {
-      return `${WRAPPER_CSS_ID}.${cssDeclaration.name}{content:"#{inspect(${cssDeclaration.value})}";}`;
+      return `${WRAPPER_CSS_ID}._${cssDeclaration.name}{content:"#{inspect(${cssDeclaration.value})}";}`;
     }
-    return `${WRAPPER_CSS_ID}.${cssDeclaration.name}{content:"#{${cssDeclaration.value}}";}`;
+    return `${WRAPPER_CSS_ID}._${cssDeclaration.name}{content:"#{${cssDeclaration.value}}";}`;
   }
 
   public static removeDoubleQuotes(wrappedContent: string): string {

--- a/test/scss/_maps.scss
+++ b/test/scss/_maps.scss
@@ -35,3 +35,10 @@ $funcs: (
   'rgba': rgba(255, 0, 0, .5),
   'darken': darken(#b37399, 20%)
 );
+
+// @sass-export-section="levels"
+$levels: (
+  100: 80%,
+  500: 0,
+  900: 80%
+);


### PR DESCRIPTION
This PR adds support for [Sass Maps](https://sass-lang.com/documentation/values/maps) that have numeric keys. It does this by updating the sass-export parser to allow a digit to appear as the first character in map keys--this appears to be valid Sass, as the following Gist shows:

https://gist.github.com/davidsmith2/99d0ce1a7017690844e2adf80300b7aa

Resolves #74