### PR TITLE
Nested maps from imports

### DIFF
--- a/src/app/converter/converter.test.ts
+++ b/src/app/converter/converter.test.ts
@@ -122,22 +122,16 @@ describe('Converter class', () => {
   });
 
   describe('includePaths support', () => {
+    const opts = { inputFiles: [path.resolve('./test/scss/_with-import.scss')], includePaths: [] };
+    opts.includePaths = [path.resolve('./test/scss/')];
+    const converter = new Converter(opts);
+    const structured = converter.getStructured();
 
     it('should import variables from other files', () => {
-      let opts = { inputFiles: [path.resolve('./test/scss/_with-import.scss')], includePaths: [] };
-      opts.includePaths = [path.resolve('./test/scss/')];
-      let converter = new Converter(opts);
-      let structured = converter.getStructured();
-
       expect(structured.variables[0]).to.have.property('compiledValue');
     });
 
     it('should parse map imports from other files', () => {
-      let opts = { inputFiles: [path.resolve('./test/scss/_with-import.scss')], includePaths: [] };
-      opts.includePaths = [path.resolve('./test/scss/')];
-      let converter = new Converter(opts);
-      let structured = converter.getStructured();
-
       expect(structured.variables[1].mapValue[0].mapValue[0]).to.have.property('compiledValue');
       expect(structured.variables[1].mapValue[0].mapValue[0].name).to.be.equal('breakpoints');
     });

--- a/src/app/converter/converter.test.ts
+++ b/src/app/converter/converter.test.ts
@@ -82,7 +82,7 @@ describe('Converter class', () => {
       results = converter.getArray();
     });
 
-    it('should include variables form both files', () => {
+    it('should include variables from both files', () => {
       let foundFirst = Utils.getDeclarationByName(results, '$brand-solitude');
       expect(foundFirst.value).to.equal('#ebeff2');
 
@@ -130,6 +130,16 @@ describe('Converter class', () => {
       let structured = converter.getStructured();
 
       expect(structured.variables[0]).to.have.property('compiledValue');
+    });
+
+    it('should parse map imports from other files', () => {
+      let opts = { inputFiles: [path.resolve('./test/scss/_with-import.scss')], includePaths: [] };
+      opts.includePaths = [path.resolve('./test/scss/')];
+      let converter = new Converter(opts);
+      let structured = converter.getStructured();
+
+      expect(structured.variables[1].mapValue[0].mapValue[0]).to.have.property('compiledValue');
+      expect(structured.variables[1].mapValue[0].mapValue[0].name).to.be.equal('breakpoints');
     });
   });
 

--- a/src/app/converter/converter.ts
+++ b/src/app/converter/converter.ts
@@ -68,7 +68,7 @@ export class Converter {
 
         if (declaration.mapValue) {
           declaration.mapValue.map((mapDeclaration) => {
-            this.compiledMapStructure(mapDeclaration);
+            this.compileMapStructure(mapDeclaration);
             return mapDeclaration;
           });
         }
@@ -80,7 +80,7 @@ export class Converter {
     return this.checkForMixins(structuredDeclaration);
   }
 
-  private compiledMapStructure(structuredDeclaration: IDeclaration)
+  private compileMapStructure(structuredDeclaration: IDeclaration)
   {
     let content = this.getContent();
     var parser = new Parser(content);
@@ -96,7 +96,7 @@ export class Converter {
           `$${declaration};`,
           true
         );
-        this.compiledMapStructure(singleDeclaration);
+        this.compileMapStructure(singleDeclaration);
 
         return singleDeclaration;
       });

--- a/src/app/converter/converter.ts
+++ b/src/app/converter/converter.ts
@@ -68,7 +68,7 @@ export class Converter {
 
         if (declaration.mapValue) {
           declaration.mapValue.map((mapDeclaration) => {
-            mapDeclaration.compiledValue = this.renderPropertyValue(content, mapDeclaration, true);
+            this.compiledMapStructure(mapDeclaration);
             return mapDeclaration;
           });
         }
@@ -78,6 +78,29 @@ export class Converter {
     });
 
     return this.checkForMixins(structuredDeclaration);
+  }
+
+  private compiledMapStructure(structuredDeclaration: IDeclaration)
+  {
+    let content = this.getContent();
+    var parser = new Parser(content);
+
+    // set compiledValue
+    structuredDeclaration.compiledValue = this.renderPropertyValue(content, structuredDeclaration, true);
+
+    // set mapValue
+    let map = parser.extractMapDeclarations(structuredDeclaration.compiledValue);
+    if (map.length) {
+      structuredDeclaration.mapValue = map.map((declaration) => {
+        const singleDeclaration = parser.parseSingleDeclaration(
+          `$${declaration};`,
+          true
+        );
+        this.compiledMapStructure(singleDeclaration);
+
+        return singleDeclaration;
+      });
+    }
   }
 
 

--- a/src/app/parser/parser.ts
+++ b/src/app/parser/parser.ts
@@ -96,7 +96,7 @@ export class Parser {
     return matches as any;
   }
 
-  private extractMapDeclarations(content: string): [any] {
+  public extractMapDeclarations(content: string): [any] {
     const matches = content.match(new RegExp(MAP_DECLARATIOM_REGEX, 'g'));
 
     if (!matches) {
@@ -107,7 +107,7 @@ export class Parser {
   }
 
 
-  private parseSingleDeclaration(matchDeclaration: string, isMap: boolean = false): IDeclaration {
+  public parseSingleDeclaration(matchDeclaration: string, isMap: boolean = false): IDeclaration {
     let matches = matchDeclaration
       .replace(/\s*!(default|global)\s*;/, ';')
       .match(new RegExp(this.getDeclarationPattern(isMap)));

--- a/test/scss/_maps.scss
+++ b/test/scss/_maps.scss
@@ -42,3 +42,9 @@ $levels: (
   500: 0,
   900: 80%
 );
+
+$container-map: (
+  'breakpoints': $bps,
+  'icons': $icons,
+  'levels': $levels
+);

--- a/test/scss/_with-import.scss
+++ b/test/scss/_with-import.scss
@@ -1,3 +1,8 @@
 @import "breakpoints";
+@import "maps";
 
 $imported-value: $bp-desktop;
+
+$nested-map-import: (
+  "imported-map": $container-map
+);

--- a/test/scss/_with-import.scss
+++ b/test/scss/_with-import.scss
@@ -3,6 +3,7 @@
 
 $imported-value: $bp-desktop;
 
-$nested-map-import: (
-  "imported-map": $container-map
+$imported-maps: (
+  "container-map-copy": $container-map,
+  "bps-copy": $bps
 );


### PR DESCRIPTION
Since the parser does not have options for the included paths (paths to imported files), the imported variables are not compiled when `converter.getStructured()` invokes `parser.parseStructured()`.

This is not an issue for imports that are top level variables. This is because the variable will be computed when invoking `converter.renderPropertyValue()` later on in the `converter.compileStructure()` method. However, an issue occurs for nested variables that are referenced from an external file. This is because the nested variable inside the map will not have knowledge about the contents of the imported map since the Parser does not have knowledge of the `includedPaths`.

Steps to reproduce:
1. Create an SCSS file called `_test-map.scss` with the following contents
```scss
@use 'sass:color';

$map: (
  'palette': (
    'primary': (
      'main': blue,
      'light': color.scale(blue, $lightness: 15%),
      'dark': color.scale(blue, $lightness: -15%),
      'contrast-text': white,
    )
  )
);
```
2. Create a file called `test-import.scss` with the following contents
```scss
@import './test-map';

$map-container: (
  $map-copy: $map
);
```
3. Run "sass-export test-import.scss -d . -o test-import.json" to parse the `test-import.scss` file and see that it fails to parse the imported map variable
4. Observe that while the output displays the full `compiledValue`, it does not flesh out the `mapValue` of the full nested map

This solves the issue by parsing the compiled value of a map property before evaluating if it is a nested map and then evaluating the contents of the nested map.

One downside to this method is that there are some methods in the Parser that had to be made public. And it would potentially be more efficient to handle the import logic within the parser and correctly parse the full path all in one shot. But that would require more restructuring and require passing in the `includedPaths` to the Parser.

There are also some other bugs with parsing/compiling maps that are not handled by this PR. Such as copying a map directly to another variable.